### PR TITLE
indicators overlay top bar

### DIFF
--- a/src/components/Indicator.js
+++ b/src/components/Indicator.js
@@ -1,0 +1,5 @@
+import { Indicator as MantineIndicator } from "@mantine/core";
+
+export default function Indicator(props) {
+  return <MantineIndicator zIndex={10} {...props} />;
+}

--- a/src/pages/user/books/ViewBooks.js
+++ b/src/pages/user/books/ViewBooks.js
@@ -2,13 +2,13 @@ import {
   Button,
   Group,
   Image,
-  Indicator,
   Select,
   Stack,
   Text,
   Title,
   Tooltip,
 } from "@mantine/core";
+import Indicator from "components/Indicator";
 import { UserContext } from "context/UserContext";
 import sortCategories from "data/sortCategories";
 import { getStatusByName } from "data/statuses";


### PR DESCRIPTION
Fixes #4

# Solution

The `zIndex` for `Indicator` components was set to `100`, presumably to keep them above their content. I tried removing the property and that caused the `Indicator` to fall behind its related content. I made a new internal component by the same name, and set `zIndex` to `10`, which solved both problems.