### PR TITLE
make title and author required in the book form

### DIFF
--- a/src/pages/user/books/BookForm.js
+++ b/src/pages/user/books/BookForm.js
@@ -38,11 +38,13 @@ export default function BookForm({ onSubmit, book, submitText }) {
         <TextInput
           label="Title"
           description="What is your new favorite book called?"
+          required
           {...form.getInputProps("title")}
         />
         <TextInput
           label="Author"
           description="Who wrote your new favorite book?"
+          required
           {...form.getInputProps("author")}
         />
         <TextInput
@@ -66,6 +68,7 @@ export default function BookForm({ onSubmit, book, submitText }) {
           label="Status"
           data={categories}
           itemComponent={Option}
+          required
           {...form.getInputProps("status")}
         />
         <Button type="submit">{submitText}</Button>


### PR DESCRIPTION
Fixes #20

# Solution

Also required status, as an error was produced without it. Makes sense, too.